### PR TITLE
Add initial RuneLite extension

### DIFF
--- a/mind-agents/package.json
+++ b/mind-agents/package.json
@@ -58,7 +58,8 @@
     "./src/extensions/telegram",
     "./src/extensions/mcp-server",
     "./src/extensions/mcp-client",
-    "./src/extensions/communication"
+    "./src/extensions/communication",
+    "./src/extensions/runelite"
   ],
   "scripts": {
     "preinstall": "echo '📦 Installing workspace dependencies...'",

--- a/mind-agents/src/extensions/index.ts
+++ b/mind-agents/src/extensions/index.ts
@@ -9,6 +9,7 @@ import { runtimeLogger } from '../utils/logger';
 
 import { ApiExtension } from './api/index';
 import { MCPServerExtension } from './mcp-server/index';
+import { createRuneLiteExtension } from './runelite/index';
 import { createTelegramExtension } from './telegram/index';
 
 export async function registerExtensions(
@@ -105,6 +106,26 @@ export async function registerExtensions(
     }
   }
 
+  // Register RuneLite extension if configured
+  if (config.extensions.runelite?.enabled) {
+    try {
+      const runeliteConfig = {
+        enabled: true,
+        settings: {
+          port: config.extensions.runelite.settings?.port || 8081,
+          events: config.extensions.runelite.settings?.events || [],
+          ...config.extensions.runelite.settings,
+        },
+      };
+      const runeliteExtension = createRuneLiteExtension(runeliteConfig);
+      extensions.push(runeliteExtension);
+      runtimeLogger.info('✅ RuneLite extension registered');
+    } catch (error) {
+      void error;
+      runtimeLogger.warn('⚠️ Failed to load RuneLite extension:', error);
+    }
+  }
+
   // MCP Client extension removed - MCP tools now handled directly in portal integration
 
   // Register MCP Server extension if configured
@@ -153,6 +174,11 @@ export {
   createTelegramExtension,
   type TelegramConfig,
 } from './telegram/index';
+export {
+  RuneLiteExtension,
+  createRuneLiteExtension,
+  type RuneLiteConfig,
+} from './runelite/index';
 // export { MCPClientExtension, type MCPClientConfig } from './mcp-client/index'
 // export { MCPServerExtension, type MCPServerConfig } from './mcp-server/index'
 // export { CommunicationExtension, type CommunicationConfig } from './communication/index'

--- a/mind-agents/src/extensions/runelite/index.ts
+++ b/mind-agents/src/extensions/runelite/index.ts
@@ -1,0 +1,159 @@
+import { v4 as uuidv4 } from 'uuid';
+import { WebSocketServer, WebSocket } from 'ws';
+
+import {
+  Extension,
+  ExtensionType,
+  ExtensionStatus,
+  Agent,
+  ExtensionAction,
+  ExtensionEventHandler,
+  ActionCategory,
+  ActionResult,
+  ActionResultType,
+  AgentEvent,
+} from '../../types/agent.js';
+import { SkillParameters } from '../../types/common.js';
+import { runtimeLogger } from '../../utils/logger.js';
+
+import { RuneLiteConfig, GameEvent, RuneLiteCommand } from './types.js';
+
+export class RuneLiteExtension implements Extension {
+  public readonly id = 'runelite';
+  public readonly name = 'RuneLite Extension';
+  public readonly version = '1.0.0';
+  public readonly type = ExtensionType.GAME_INTEGRATION;
+  public enabled = true;
+  public status = ExtensionStatus.STOPPED;
+  public actions: Record<string, ExtensionAction> = {};
+  public events: Record<string, ExtensionEventHandler> = {};
+
+  public config: RuneLiteConfig;
+  private wss?: WebSocketServer;
+  private clients = new Map<string, WebSocket>();
+  private agent?: Agent;
+
+  constructor(config: RuneLiteConfig) {
+    this.config = {
+      enabled: config.enabled ?? true,
+      priority: config.priority ?? 1,
+      settings: {
+        port: 8081,
+        events: [],
+        ...config.settings,
+      },
+    };
+
+    this.registerExtensionActions();
+  }
+
+  async init(agent: Agent): Promise<void> {
+    if (!this.config.enabled) {
+      runtimeLogger.info('⏸️ RuneLite extension is disabled');
+      return;
+    }
+
+    this.agent = agent;
+    const port = this.config.settings.port ?? 8081;
+
+    this.wss = new WebSocketServer({ port });
+    this.wss.on('connection', (ws) => {
+      const id = uuidv4();
+      this.clients.set(id, ws);
+
+      ws.on('message', (data) => {
+        try {
+          const event = JSON.parse(data.toString()) as GameEvent;
+          void this.handleGameEvent(id, event);
+        } catch (err) {
+          runtimeLogger.warn('⚠️ RuneLite event parse error', err);
+        }
+      });
+
+      ws.on('close', () => {
+        this.clients.delete(id);
+      });
+    });
+
+    this.status = ExtensionStatus.RUNNING;
+    runtimeLogger.info(`🎮 RuneLite extension listening on port ${port}`);
+  }
+
+  async tick(_agent: Agent): Promise<void> {
+    // No periodic tasks yet
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.wss) {
+      this.wss.close();
+      this.wss = undefined;
+    }
+    this.clients.clear();
+    this.status = ExtensionStatus.STOPPED;
+    runtimeLogger.info('🎮 RuneLite extension stopped');
+  }
+
+  private async handleGameEvent(
+    clientId: string,
+    event: GameEvent
+  ): Promise<void> {
+    if (!this.agent) return;
+
+    const agentEvent: AgentEvent = {
+      id: `${clientId}-${Date.now()}`,
+      type: 'game_event',
+      source: 'runelite',
+      data: event,
+      timestamp: new Date(),
+      processed: false,
+      agentId: this.agent.id,
+    };
+
+    if (this.agent.eventBus) {
+      await this.agent.eventBus.emit('game.event', agentEvent);
+    }
+  }
+
+  private sendCommand(command: RuneLiteCommand): void {
+    const payload = JSON.stringify({ type: 'command', command });
+    for (const ws of this.clients.values()) {
+      ws.send(payload);
+    }
+  }
+
+  private registerExtensionActions(): void {
+    this.actions['sendCommand'] = {
+      name: 'sendCommand',
+      description: 'Send a command to RuneLite clients',
+      category: ActionCategory.INTERACTION,
+      parameters: {
+        command: {
+          type: 'string',
+          required: true,
+          description: 'Command name',
+        },
+        args: {
+          type: 'object',
+          required: false,
+          description: 'Command arguments',
+        },
+      },
+      execute: async (
+        _agent: Agent,
+        params: SkillParameters
+      ): Promise<ActionResult> => {
+        this.sendCommand({
+          name: params.command as string,
+          args: params.args as Record<string, unknown> | undefined,
+        });
+        return { success: true, type: ActionResultType.SUCCESS };
+      },
+    };
+  }
+}
+
+export function createRuneLiteExtension(
+  config: RuneLiteConfig
+): RuneLiteExtension {
+  return new RuneLiteExtension(config);
+}

--- a/mind-agents/src/extensions/runelite/package.json
+++ b/mind-agents/src/extensions/runelite/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@symindx/extension-runelite",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "main": "index.ts",
+  "dependencies": {
+    "ws": "^8.18.2",
+    "uuid": "^11.0.0"
+  },
+  "symindx": {
+    "type": "extension",
+    "displayName": "RuneLite Integration",
+    "description": "Connect SYMindX agents to RuneLite for real-time game automation",
+    "category": "game",
+    "extension": {
+      "type": "runelite",
+      "factory": "createRuneLiteExtension",
+      "autoRegister": true
+    }
+  },
+  "peerDependencies": {
+    "@symindx/types": "workspace:*"
+  }
+}

--- a/mind-agents/src/extensions/runelite/types.ts
+++ b/mind-agents/src/extensions/runelite/types.ts
@@ -1,0 +1,20 @@
+import { ExtensionConfig } from '../../types/common.js';
+
+export interface RuneLiteSettings {
+  port?: number;
+  events?: string[];
+}
+
+export interface RuneLiteConfig extends ExtensionConfig {
+  settings: RuneLiteSettings;
+}
+
+export interface GameEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface RuneLiteCommand {
+  name: string;
+  args?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add RuneLite extension skeleton with WebSocket server
- register RuneLite extension
- include extension workspace in package configuration

## Testing
- `bun test` *(fails: INVALID_API_KEY_FORMAT, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687de98a3c3c8321bd5b97e108ea053e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration with RuneLite, enabling real-time communication and automation between SYMindX agents and the RuneLite game client.
  * Introduced support for receiving game events and sending commands to RuneLite clients.
  * Provided configuration options for customizing RuneLite extension settings.

* **Chores**
  * Updated workspace configuration to include the new RuneLite extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->