### PR TITLE
Improve typing in memory modules

### DIFF
--- a/mind-agents/src/modules/memory/advanced-search-engine.ts
+++ b/mind-agents/src/modules/memory/advanced-search-engine.ts
@@ -622,7 +622,10 @@ export class AdvancedSearchEngine {
   /**
    * Get field value from memory record
    */
-  private getFieldValue(memory: MemoryRecord, field: string): any {
+  private getFieldValue(
+    memory: MemoryRecord,
+    field: string
+  ): string | number | string[] | undefined {
     switch (field) {
       case 'type':
         return memory.type;
@@ -633,7 +636,7 @@ export class AdvancedSearchEngine {
       case 'content':
         return memory.content;
       default:
-        return memory.metadata[field];
+        return memory.metadata[field] as string | number | string[] | undefined;
     }
   }
 
@@ -643,9 +646,9 @@ export class AdvancedSearchEngine {
    */
 
   private _applyFilter(
-    value: any,
+    value: string | number | boolean | string[],
     operator: string,
-    filterValue: any
+    filterValue: string | number | boolean | string[]
   ): boolean {
     switch (operator) {
       case 'eq':

--- a/mind-agents/src/modules/memory/base-memory-provider.ts
+++ b/mind-agents/src/modules/memory/base-memory-provider.ts
@@ -80,6 +80,14 @@ export interface MemoryRow {
 }
 
 /**
+ * Basic health check result for memory providers
+ */
+export interface MemoryHealthCheckResult {
+  status: 'healthy' | 'unhealthy';
+  details?: Record<string, unknown>;
+}
+
+/**
  * Enhanced memory record with tier and context
  */
 export interface EnhancedMemoryRecord extends MemoryRecord {
@@ -902,8 +910,10 @@ export abstract class BaseMemoryProvider implements MemoryProvider {
 
     // Agent state insights
     if (context.agent?.emotionalState) {
-      const emotions = Object.entries(context.agent.emotionalState)
-        .filter(([_, value]) => (value as any)?.intensity > 0.5)
+      const emotions = Object.entries(
+        context.agent.emotionalState as Record<string, { intensity: number }>
+      )
+        .filter(([, value]) => value.intensity > 0.5)
         .map(([emotion]) => emotion);
       
       if (emotions.length > 0) {
@@ -1306,7 +1316,7 @@ export abstract class BaseMemoryProvider implements MemoryProvider {
    * Health check for the memory provider
    * @returns Health check result
    */
-  async healthCheck(): Promise<{ status: string; details?: any }> {
+  async healthCheck(): Promise<MemoryHealthCheckResult> {
     try {
       // Basic health check - subclasses can override
       return {

--- a/mind-agents/src/modules/memory/chat-integration.ts
+++ b/mind-agents/src/modules/memory/chat-integration.ts
@@ -17,6 +17,9 @@ import {
   ChatRepository,
   ChatSystemConfig,
   ConversationStatus,
+  MessageStatus,
+  MessageType,
+  SenderType,
 } from './providers/sqlite/chat-types';
 import {
   createSupabaseChatRepository,
@@ -152,7 +155,7 @@ export async function getChatSystemStatus(repository: ChatRepository): Promise<{
       agentId: 'test-agent',
       userId: 'test-user',
       title: 'Health Check',
-      status: 'active' as ConversationStatus,
+      status: ConversationStatus.ACTIVE,
       messageCount: 0,
       metadata: { healthCheck: true },
     });
@@ -160,14 +163,14 @@ export async function getChatSystemStatus(repository: ChatRepository): Promise<{
 
     await repository.createMessage({
       conversationId: testConversation.id,
-      senderType: 'system' as any,
+      senderType: SenderType.SYSTEM,
       senderId: 'system',
       content: 'Health check message',
-      messageType: 'text' as any,
+      messageType: MessageType.TEXT,
       metadata: {},
       memoryReferences: [],
       createdMemories: [],
-      status: 'sent' as any,
+      status: MessageStatus.SENT,
     });
     details.canCreateMessage = true;
 


### PR DESCRIPTION
## Summary
- refine enums usage in chat integration
- enhance type safety in advanced memory search
- add health check result type and better emotion filtering in base provider

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_688877ab01b083219222c817a85f7b29